### PR TITLE
Fix StorageClass value compare bug

### DIFF
--- a/apis/shared/resources.go
+++ b/apis/shared/resources.go
@@ -89,7 +89,7 @@ func (r *Resources) ValidateUpdate(oldResources *Resources) (errors field.ErrorL
 	}
 
 	// storage class is immutable
-	if oldStorageClass != r.StorageClass {
+	if oldStorageClass != nil && r.StorageClass != nil && *oldStorageClass != *r.StorageClass {
 		msg := "field is immutable"
 		err := field.Invalid(field.NewPath("spec").Child("resources").Child("storageClass"), r.StorageClass, msg)
 		errors = append(errors, err)


### PR DESCRIPTION
Hi.
`StorageClass` is defined as a pointer type. Pointer variables directly compare not the real value, but the reference address.So we should use `*oldStorageClass != *r.StorageClass` for comparison, not `oldStorageClass != r.StorageClass`.

Thank you!
