### PR TITLE
Make Polkadot support `--rpc-methods` param

### DIFF
--- a/apis/polkadot/v1alpha1/node.go
+++ b/apis/polkadot/v1alpha1/node.go
@@ -50,6 +50,8 @@ type NodeSpec struct {
 	RPC bool `json:"rpc,omitempty"`
 	// RPCPort is JSON-RPC server port
 	RPCPort uint `json:"rpcPort,omitempty"`
+	// RPCMethods is JSON-RPC methods access control
+	RPCMethods string `json:"rpcMethods,omitempty"`
 	// WS enables Websocket server
 	WS bool `json:"ws,omitempty"`
 	// WSPort is Websocket server port

--- a/clients/polkadot/polkadot_client.go
+++ b/clients/polkadot/polkadot_client.go
@@ -70,6 +70,8 @@ func (c *PolkadotClient) Args() (args []string) {
 	if node.Spec.RPC {
 		args = append(args, PolkadotArgRPCExternal)
 		args = append(args, PolkadotArgRPCPort, fmt.Sprintf("%d", node.Spec.RPCPort))
+		args = append(args, PolkadotArgRPCMethods, node.Spec.RPCMethods)
+
 	}
 
 	if node.Spec.WS {

--- a/clients/polkadot/polkadot_client_test.go
+++ b/clients/polkadot/polkadot_client_test.go
@@ -29,6 +29,7 @@ var _ = Describe("Polkadot client", func() {
 			Logging:                  "warn",
 			RPC:                      true,
 			RPCPort:                  6789,
+			RPCMethods:               "unsafe",
 			WS:                       true,
 			WSPort:                   3456,
 			Telemetry:                true,

--- a/clients/polkadot/types.go
+++ b/clients/polkadot/types.go
@@ -21,6 +21,8 @@ const (
 	PolkadotArgRPCPort = "--rpc-port"
 	// PolkadotArgRPCCors is argument used to set origins allowed to access the JSON-RPC HTTP and WS servers
 	PolkadotArgRPCCors = "--rpc-cors"
+	// PolkadotArgRPCMethods is argument used to set allowed to access the JSON-RPC methods
+	PolkadotArgRPCMethods = "--rpc-methods"
 	// PolkadotArgWSExternal is argument used to enable websocket server
 	PolkadotArgWSExternal = "--ws-external"
 	// PolkadotArgWSPort is argument used to set websocket server port


### PR DESCRIPTION
### Parameter description
```
--rpc-methods <METHOD SET>
            RPC methods to expose. [default: auto] [possible values: auto, safe, unsafe]
```
### Why support this parameter about `--rpc-methods` ?
I want to get some information about Polkadot for `peerCount`,`currentBlock`,`highestBlock`. 
If you want to get this information, I need to access the following RPC method:
- system_syncState
```json
{"jsonrpc":"2.0","result":{"startingBlock":0,"·":6321799,"highestBlock":10525440},"id":1}
```
- system_health
```json
{"jsonrpc":"2.0","result":{"peers":41,"isSyncing":true,"shouldHavePeers":true},"id":32}
```
<br>
However, to implement the above functions, I need to use the following parameters:`--rpc-methods=unsafe`.
But our system does not support this parameter at present.


### Result
This configuration has been applied and verified in our project, which is feasible.




