### PR TITLE
Shanghai upgrade for Ethereum nodes (genesis config)

### DIFF
--- a/apis/ethereum/v1alpha1/genesis.go
+++ b/apis/ethereum/v1alpha1/genesis.go
@@ -23,6 +23,9 @@ type Genesis struct {
 	// MixHash is hash combined with nonce to prove effort spent to create block
 	MixHash Hash `json:"mixHash,omitempty"`
 
+	// ExtraData is arbitrary data to include in block
+	ExtraData string `json:"extraData,omitempty"`
+
 	// ParentHash is the hash value of the previous block
 	ParentHash Hash `json:"parentHash,omitempty"`
 

--- a/apis/ethereum/v1alpha1/genesis.go
+++ b/apis/ethereum/v1alpha1/genesis.go
@@ -23,6 +23,9 @@ type Genesis struct {
 	// MixHash is hash combined with nonce to prove effort spent to create block
 	MixHash Hash `json:"mixHash,omitempty"`
 
+	// ParentHash is the hash value of the previous block
+	ParentHash Hash `json:"parentHash,omitempty"`
+
 	// Ethash PoW engine configuration
 	Ethash *Ethash `json:"ethash,omitempty"`
 
@@ -133,6 +136,15 @@ type Forks struct {
 
 	// ArrowGlacier fork
 	ArrowGlacier uint `json:"arrowGlacier,omitempty"`
+
+	// MergeFor fork
+	MergeFor uint `json:"mergeFor,omitempty"`
+
+	// TerminalTotalDifficulty fork
+	TerminalTotalDifficulty uint `json:"terminalTotalDifficulty,omitempty"`
+
+	// ShanghaiTime timestamp-based fork
+	ShanghaiTime uint `json:"shanghaiTime,omitempty"`
 }
 
 // Account is Ethereum account

--- a/clients/ethereum/besu_client.go
+++ b/clients/ethereum/besu_client.go
@@ -138,8 +138,9 @@ func (b *BesuClient) Genesis() (content string, err error) {
 	node := b.node
 	genesis := node.Spec.Genesis
 	mixHash := genesis.MixHash
+	parentHash := genesis.ParentHash
 	nonce := genesis.Nonce
-	extraData := "0x00"
+	extraData := genesis.ExtraData
 	difficulty := genesis.Difficulty
 	result := map[string]interface{}{}
 
@@ -190,20 +191,23 @@ func (b *BesuClient) Genesis() (content string, err error) {
 	}
 
 	config := map[string]interface{}{
-		"chainId":             genesis.ChainID,
-		"homesteadBlock":      genesis.Forks.Homestead,
-		"eip150Block":         genesis.Forks.EIP150,
-		"eip155Block":         genesis.Forks.EIP155,
-		"eip158Block":         genesis.Forks.EIP158,
-		"byzantiumBlock":      genesis.Forks.Byzantium,
-		"constantinopleBlock": genesis.Forks.Constantinople,
-		"petersburgBlock":     genesis.Forks.Petersburg,
-		"istanbulBlock":       genesis.Forks.Istanbul,
-		"muirGlacierBlock":    genesis.Forks.MuirGlacier,
-		"berlinBlock":         genesis.Forks.Berlin,
-		"londonBlock":         genesis.Forks.London,
-		"arrowGlacierBlock":   genesis.Forks.ArrowGlacier,
-		engine:                consensusConfig,
+		"chainId":                 genesis.ChainID,
+		"homesteadBlock":          genesis.Forks.Homestead,
+		"eip150Block":             genesis.Forks.EIP150,
+		"eip155Block":             genesis.Forks.EIP155,
+		"eip158Block":             genesis.Forks.EIP158,
+		"byzantiumBlock":          genesis.Forks.Byzantium,
+		"constantinopleBlock":     genesis.Forks.Constantinople,
+		"petersburgBlock":         genesis.Forks.Petersburg,
+		"istanbulBlock":           genesis.Forks.Istanbul,
+		"muirGlacierBlock":        genesis.Forks.MuirGlacier,
+		"berlinBlock":             genesis.Forks.Berlin,
+		"londonBlock":             genesis.Forks.London,
+		"arrowGlacierBlock":       genesis.Forks.ArrowGlacier,
+		"mergeForBlock":           genesis.Forks.MergeFor,
+		"terminalTotalDifficulty": genesis.Forks.TerminalTotalDifficulty,
+		"shanghaiTime":            genesis.Forks.ShanghaiTime,
+		engine:                    consensusConfig,
 	}
 
 	if genesis.Forks.DAO != nil {
@@ -223,6 +227,7 @@ func (b *BesuClient) Genesis() (content string, err error) {
 	result["gasLimit"] = genesis.GasLimit
 	result["difficulty"] = difficulty
 	result["coinbase"] = genesis.Coinbase
+	result["parentHash"] = parentHash
 	result["mixHash"] = mixHash
 	result["extraData"] = extraData
 

--- a/clients/ethereum/geth_client.go
+++ b/clients/ethereum/geth_client.go
@@ -185,7 +185,7 @@ func (g *GethClient) Genesis() (content string, err error) {
 	mixHash := genesis.MixHash
 	parentHash := genesis.ParentHash
 	nonce := genesis.Nonce
-	extraData := "0x00"
+	extraData := genesis.ExtraData
 	difficulty := genesis.Difficulty
 	result := map[string]interface{}{}
 

--- a/clients/ethereum/geth_client.go
+++ b/clients/ethereum/geth_client.go
@@ -183,6 +183,7 @@ func (g *GethClient) Genesis() (content string, err error) {
 	node := g.node
 	genesis := node.Spec.Genesis
 	mixHash := genesis.MixHash
+	parentHash := genesis.ParentHash
 	nonce := genesis.Nonce
 	extraData := "0x00"
 	difficulty := genesis.Difficulty
@@ -208,20 +209,23 @@ func (g *GethClient) Genesis() (content string, err error) {
 	}
 
 	config := map[string]interface{}{
-		"chainId":             genesis.ChainID,
-		"homesteadBlock":      genesis.Forks.Homestead,
-		"eip150Block":         genesis.Forks.EIP150,
-		"eip155Block":         genesis.Forks.EIP155,
-		"eip158Block":         genesis.Forks.EIP158,
-		"byzantiumBlock":      genesis.Forks.Byzantium,
-		"constantinopleBlock": genesis.Forks.Constantinople,
-		"petersburgBlock":     genesis.Forks.Petersburg,
-		"istanbulBlock":       genesis.Forks.Istanbul,
-		"muirGlacierBlock":    genesis.Forks.MuirGlacier,
-		"berlinBlock":         genesis.Forks.Berlin,
-		"londonBlock":         genesis.Forks.London,
-		"arrowGlacierBlock":   genesis.Forks.ArrowGlacier,
-		engine:                consensusConfig,
+		"chainId":                 genesis.ChainID,
+		"homesteadBlock":          genesis.Forks.Homestead,
+		"eip150Block":             genesis.Forks.EIP150,
+		"eip155Block":             genesis.Forks.EIP155,
+		"eip158Block":             genesis.Forks.EIP158,
+		"byzantiumBlock":          genesis.Forks.Byzantium,
+		"constantinopleBlock":     genesis.Forks.Constantinople,
+		"petersburgBlock":         genesis.Forks.Petersburg,
+		"istanbulBlock":           genesis.Forks.Istanbul,
+		"muirGlacierBlock":        genesis.Forks.MuirGlacier,
+		"berlinBlock":             genesis.Forks.Berlin,
+		"londonBlock":             genesis.Forks.London,
+		"arrowGlacierBlock":       genesis.Forks.ArrowGlacier,
+		"mergeForBlock":           genesis.Forks.MergeFor,
+		"terminalTotalDifficulty": genesis.Forks.TerminalTotalDifficulty,
+		"shanghaiTime":            genesis.Forks.ShanghaiTime,
+		engine:                    consensusConfig,
 	}
 
 	if genesis.Forks.DAO != nil {
@@ -237,6 +241,7 @@ func (g *GethClient) Genesis() (content string, err error) {
 	result["difficulty"] = difficulty
 	result["coinbase"] = genesis.Coinbase
 	result["mixHash"] = mixHash
+	result["parentHash"] = parentHash
 	result["extraData"] = extraData
 
 	alloc := genesisAccounts(false, genesis.Forks)

--- a/clients/ethereum/parity_genesis.go
+++ b/clients/ethereum/parity_genesis.go
@@ -20,7 +20,7 @@ func (p *ParityGenesis) NormalizeNonce(data string) string {
 // Genesis returns genesis config parameter
 func (p *ParityGenesis) Genesis(node *ethereumv1alpha1.Node) (content string, err error) {
 	genesis := node.Spec.Genesis
-	extraData := "0x00"
+	extraData := genesis.ExtraData
 	var engineConfig map[string]interface{}
 
 	// clique PoA settings
@@ -51,6 +51,9 @@ func (p *ParityGenesis) Genesis(node *ethereumv1alpha1.Node) (content string, er
 	berlinBlock := hex(genesis.Forks.Berlin)
 	londonBlock := hex(genesis.Forks.London)
 	arrowGlacierBlock := hex(genesis.Forks.ArrowGlacier)
+	mergeForBlock := hex(genesis.Forks.MergeFor)
+	terminalTotalDifficulty := hex(genesis.Forks.TerminalTotalDifficulty)
+	shanghaiTime := hex(genesis.Forks.ShanghaiTime)
 
 	// ethash PoW settings
 	if genesis.Ethash != nil {
@@ -92,7 +95,7 @@ func (p *ParityGenesis) Genesis(node *ethereumv1alpha1.Node) (content string, er
 				"mixHash": genesis.MixHash,
 			},
 		},
-		"parentHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+		"parentHash": genesis.ParentHash,
 		"timestamp":  genesis.Timestamp,
 		"gasLimit":   genesis.GasLimit,
 		"difficulty": genesis.Difficulty,
@@ -153,6 +156,12 @@ func (p *ParityGenesis) Genesis(node *ethereumv1alpha1.Node) (content string, er
 		"eip1559BaseFeeMaxChangeDenominator": "0x8",
 		"eip1559ElasticityMultiplier":        "0x2",
 		"eip1559BaseFeeInitialValue":         "0x3B9ACA00",
+		"mergeForkIdTransition":              mergeForBlock,
+		"eip3651TransitionTimestamp":         shanghaiTime,
+		"eip3855TransitionTimestamp":         shanghaiTime,
+		"eip3860TransitionTimestamp":         shanghaiTime,
+		"eip4895TransitionTimestamp":         shanghaiTime,
+		"terminalTotalDifficulty":            terminalTotalDifficulty,
 	}
 
 	alloc := genesisAccounts(true, genesis.Forks)

--- a/config/crd/bases/ethereum.kotal.io_nodes.yaml
+++ b/config/crd/bases/ethereum.kotal.io_nodes.yaml
@@ -191,11 +191,20 @@ spec:
                       london:
                         description: London fork
                         type: integer
+                      mergeFor:
+                        description: MergeFor fork
+                        type: integer
                       muirglacier:
                         description: MuirGlacier fork
                         type: integer
                       petersburg:
                         description: Petersburg fork
+                        type: integer
+                      shanghaiTime:
+                        description: ShanghaiTime timestamp-based fork
+                        type: integer
+                      terminalTotalDifficulty:
+                        description: TerminalTotalDifficulty fork
                         type: integer
                     type: object
                   gasLimit:
@@ -251,6 +260,10 @@ spec:
                   nonce:
                     description: Nonce is random number used in block computation
                     pattern: ^0[xX][0-9a-fA-F]+$
+                    type: string
+                  parentHash:
+                    description: ParentHash is the hash value of the previous block
+                    pattern: ^0[xX][0-9a-fA-F]{64}$
                     type: string
                   timestamp:
                     description: Timestamp is block creation date

--- a/config/crd/bases/ethereum.kotal.io_nodes.yaml
+++ b/config/crd/bases/ethereum.kotal.io_nodes.yaml
@@ -154,6 +154,9 @@ spec:
                           in private PoW networks
                         type: integer
                     type: object
+                  extraData:
+                    description: ExtraData is arbitrary data to include in block
+                    type: string
                   forks:
                     description: Forks is supported forks (network upgrade) and corresponding
                       block number


### PR DESCRIPTION
This merge request introduces some new parameters to the network configuration for handling the upcoming Shanghai upgrade like `mergeFor` and `shanghaiTime`. Additionally, It ensures the proper propagation of other properties like `terminalTotalDifficulty`, `mixHash` and `parentHash` that are needed when running a local private testnet.